### PR TITLE
feat: Add core architecture for the settings builder

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,9 +8,11 @@ parameters:
     paths:
         - src/
 
-    # Strict rules configuration
     strictRules:
         noVariableVariables: false
+
+    ignoreErrors:
+        - identifier: empty.notAllowed
 
     treatPhpDocTypesAsCertain: false
 

--- a/src/Asset_Manager.php
+++ b/src/Asset_Manager.php
@@ -15,16 +15,24 @@ namespace WPTechnix\WP_Settings_Builder;
 final class Asset_Manager {
 
 	/**
-	 * Class Constructor
+	 * The HTML prefix that will be used in generated CSS/JS.
 	 *
-	 * @param string $html_prefix HTML prefix to use in assets.
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $html_prefix = 'wptechnix-settings'; // @phpstan-ignore-line
+
+	/**
+	 * Set HTML prefix that will be used in generated CSS/JS.
+	 *
+	 * @param string $html_prefix HTML prefix.
 	 *
 	 * @phpstan-param non-empty-string $html_prefix
 	 */
-	public function __construct(
-		// @phpstan-ignore-next-line
-		private string $html_prefix
-	) {}
+	public function set_html_prefix( string $html_prefix ): void {
+		$this->html_prefix = $html_prefix;
+	}
 
 	/**
 	 * Enqueues all necessary scripts and styles for the settings page.

--- a/src/Asset_Manager.php
+++ b/src/Asset_Manager.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Manage styling and scripts for the settings page.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+/**
+ * Handles the enqueueing and rendering of all static assets for the settings page.
+ */
+final class Asset_Manager {
+
+	/**
+	 * Class Constructor
+	 *
+	 * @param string $html_prefix HTML prefix to use in assets.
+	 *
+	 * @phpstan-param non-empty-string $html_prefix
+	 */
+	public function __construct(
+		// @phpstan-ignore-next-line
+		private string $html_prefix
+	) {}
+
+	/**
+	 * Enqueues all necessary scripts and styles for the settings page.
+	 *
+	 * @internal This method is hooked into 'admin_enqueue_scripts' to loads assets (not to be called directly).
+	 */
+	public function enqueue(): void {
+	}
+}

--- a/src/Field_Factory.php
+++ b/src/Field_Factory.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Factory for creating field objects based on their type.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+use InvalidArgumentException;
+use WPTechnix\WP_Settings_Builder\Fields\Abstract_Field;
+
+/**
+ * Creates instances of field objects based on their type.
+ *
+ * @phpstan-type Text_Field_Type 'text'
+ * @phpstan-type Supported_Field_Type Text_Field_Type
+ *
+ * @phpstan-import-type Field_Config from Abstract_Field
+ */
+final class Field_Factory {
+
+	/**
+	 * A map of field types to their corresponding class names.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var array<Supported_Field_Type, class-string<Abstract_Field>>
+	 */
+	private array $fields;
+
+	/**
+	 * Class Constructor.
+	 *
+	 * Initializes the map of supported field types. This can be extended
+	 * programmatically if needed.
+	 */
+	public function __construct() {
+		$this->fields = [
+			// TODO: add fields.
+		];
+	}
+
+	/**
+	 * Get the list of all supported field type keys.
+	 *
+	 * @return string[] An array of supported type identifiers.
+	 *
+	 * @phpstan-return Supported_Field_Type[]
+	 */
+	public function get_supported_types(): array {
+		return array_keys( $this->fields );
+	}
+
+	/**
+	 * Get text-based field types.
+	 *
+	 * @return string[] An array of inline field type identifiers.
+	 *
+	 * @phpstan-return Text_Field_Type[]
+	 */
+	public function get_text_types(): array {
+		return [];
+	}
+
+	/**
+	 * Creates a field object based on its type.
+	 *
+	 * @param string $type         The field type identifier (e.g., 'text', 'toggle').
+	 * @param array  $field_config The configuration for the field.
+	 *
+	 * @phpstan-param Field_Config $field_config
+	 *
+	 * @return Abstract_Field The instantiated field object.
+	 *
+	 * @throws InvalidArgumentException If the requested field type is not supported.
+	 */
+	public function create( string $type, array $field_config ): Abstract_Field {
+		if ( ! isset( $this->fields[ $type ] ) ) {
+			throw new InvalidArgumentException( sprintf( 'Unsupported field type: "%s".', $type ) );
+		}
+
+		$class_name = $this->fields[ $type ];
+		if ( ! class_exists( $class_name ) ) {
+			throw new InvalidArgumentException( sprintf( 'Invalid field class "%s" for type "%s".', $class_name, $type ) );
+		}
+
+		return new $class_name( $field_config );
+	}
+}

--- a/src/Fields/Abstract_Field.php
+++ b/src/Fields/Abstract_Field.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Provides the basic structure and common functionality for all field types.
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use WPTechnix\WP_Settings_Builder\Interfaces\Field_Interface;
+
+/**
+ * Abstract field class to provide basic structure and common functionality.
+ *
+ * @phpstan-type Field_Config array{
+ *   id: non-empty-string,
+ *   title: non-empty-string,
+ *   section: non-empty-string,
+ *   name: non-empty-string,
+ *   type: non-empty-string,
+ *   extras: array<string,mixed>
+ * }
+ */
+abstract class Abstract_Field implements Field_Interface {
+
+	/**
+	 * Class Constructor.
+	 *
+	 * @param array $field_config  The field's config uration properties.
+	 *
+	 * @phpstan-param Field_Config $field_config
+	 */
+	public function __construct(
+		protected array $field_config,
+	) {
+	}
+
+	/**
+	 * Get the default value for the field.
+	 *
+	 * @return mixed The default value.
+	 */
+	public function get_default_value(): mixed {
+		return $this->field_config['extras']['default'] ?? null;
+	}
+
+	/**
+	 * Build an HTML attributes string from an array.
+	 *
+	 * This helper method constructs a valid HTML attribute string from an
+	 * associative array, with proper escaping.
+	 *
+	 * @param array $attributes The array of attributes (key => value).
+	 * @phpstan-param array<non-empty-string, scalar> $attributes
+	 *
+	 * @return string The generated HTML attributes string.
+	 */
+	protected function build_attributes_string( array $attributes ): string {
+		$attr_parts = [];
+		foreach ( $attributes as $key => $value ) {
+			if ( is_bool( $value ) ) {
+				if ( $value ) {
+					$attr_parts[] = esc_attr( $key );
+				}
+			} else {
+				$attr_parts[] = sprintf( '%s="%s"', esc_attr( $key ), esc_attr( (string) $value ) );
+			}
+		}
+
+		return implode( ' ', $attr_parts );
+	}
+}

--- a/src/Interfaces/Field_Interface.php
+++ b/src/Interfaces/Field_Interface.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Defines the contract for a settings field.
+ *
+ * @package WPTechnix\WP_Settings_Builder\Interfaces
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Interfaces;
+
+/**
+ * Defines the contract for a settings field.
+ */
+interface Field_Interface {
+
+	/**
+	 * Render the field's HTML markup.
+	 *
+	 * This method is responsible for echoing the complete HTML for the form element.
+	 *
+	 * @param mixed $value      The current value of the field.
+	 * @param array $attributes Additional HTML attributes for the field.
+	 *
+	 * @phpstan-param array<non-empty-string, string|int|bool> $attributes
+	 */
+	public function render( mixed $value, array $attributes ): void;
+
+	/**
+	 * Sanitize the field's value before saving.
+	 *
+	 * This method ensures the input data is clean and in the correct format
+	 * before being persisted to the database.
+	 *
+	 * @param mixed $value The raw input value to be sanitized.
+	 *
+	 * @return mixed The sanitized value.
+	 */
+	public function sanitize( mixed $value ): mixed;
+
+	/**
+	 * Get the default value for the field.
+	 *
+	 * Provides a fallback value when no value has been saved yet.
+	 *
+	 * @return mixed The default value.
+	 */
+	public function get_default_value(): mixed;
+}

--- a/src/Interfaces/Settings_Interface.php
+++ b/src/Interfaces/Settings_Interface.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Defines the public contract for a settings page builder.
+ *
+ * @package WPTechnix\WP_Settings_Builder\Interfaces
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Interfaces;
+
+use WPTechnix\WP_Settings_Builder\Field_Factory;
+
+/**
+ * Defines the public contract for a settings page builder.
+ *
+ * @phpstan-import-type Supported_Field_Type from Field_Factory
+ */
+interface Settings_Interface {
+
+	/**
+	 * Sets the main title of the settings page (the `<h1>` tag).
+	 *
+	 * @param string $page_title The main title for the settings page.
+	 *
+	 * @phpstan-param non-empty-string $page_title
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function set_page_title( string $page_title ): static;
+
+	/**
+	 * Sets the title displayed in the WordPress admin menu.
+	 *
+	 * @param string $menu_title The title for the admin menu item.
+	 *
+	 * @phpstan-param non-empty-string $menu_title
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function set_menu_title( string $menu_title ): static;
+
+	/**
+	 * Sets the required capability to view and save the settings page.
+	 *
+	 * @param string $capability The WordPress capability string (e.g., 'manage_options').
+	 *
+	 * @phpstan-param non-empty-string $capability
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function set_capability( string $capability ): static;
+
+	/**
+	 * Sets the parent menu page slug under which this settings page will appear.
+	 *
+	 * @param string $parent_slug The slug of the parent menu (e.g., 'options-general.php', 'themes.php').
+	 *
+	 * @phpstan-param non-empty-string $parent_slug
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function set_parent_slug( string $parent_slug ): static;
+
+
+	/**
+	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
+	 *
+	 * @param string $html_prefix The HTML prefix to use.
+	 *
+	 * @phpstan-param non-empty-string $html_prefix
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function set_html_prefix( string $html_prefix ): static;
+
+	/**
+	 * Adds a navigation tab to the settings page.
+	 *
+	 * This automatically enables the tabbed interface.
+	 *
+	 * @param string      $id    A unique identifier for the tab.
+	 * @param string      $title The visible title of the tab.
+	 * @param null|string $icon  (Optional) A Dashicons class for an icon (e.g., 'dashicons-admin-generic').
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param null|non-empty-string $icon
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function add_tab( string $id, string $title, ?string $icon = null ): static;
+
+	/**
+	 * Adds a settings section to group related fields.
+	 *
+	 * @param string      $id          A unique identifier for the section.
+	 * @param string      $title       The visible title of the section (an `<h2>` tag).
+	 * @param null|string $description (Optional) A short description displayed below the section title.
+	 * @param null|string $tab_id      (Optional) The ID of the tab this section belongs to. Required for tabbed interfaces.
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param null|non-empty-string $description
+	 * @phpstan-param null|non-empty-string $tab_id
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function add_section(
+		string $id,
+		string $title,
+		?string $description = null,
+		?string $tab_id = null
+	): static;
+
+	/**
+	 * Adds a setting field to a section.
+	 *
+	 * @param string $id         A unique identifier for the field, used as the key in the options array.
+	 * @param string $section_id The ID of the section this field belongs to.
+	 * @param string $type       The type of field (e.g., 'text', 'toggle', 'select').
+	 * @param string $title      The title displayed for the field.
+	 * @param array  $extras     (Optional) Additional arguments for the field, such as 'default',
+	 *                           description', 'options', 'attributes', etc.
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $section_id
+	 * @phpstan-param Supported_Field_Type $type
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param array<string, mixed> $extras
+	 *
+	 * @return static Provides a fluent interface.
+	 */
+	public function add_field(
+		string $id,
+		string $section_id,
+		string $type,
+		string $title,
+		array $extras = []
+	): static;
+
+	/**
+	 * Hooks the settings framework into the appropriate WordPress actions.
+	 * This method must be called to activate the settings page and make it appear.
+	 */
+	public function init(): void;
+
+	/**
+	 * Retrieve the setting value for given field key.
+	 *
+	 * @param string     $key The specific option key (field ID) to retrieve.
+	 * @param mixed|null $default_value A final fallback value if no saved option or field default is found.
+	 *
+	 * @phpstan-param non-empty-string $key
+	 *
+	 * @return mixed The saved value, the field's default value, or the provided default.
+	 */
+	public function get( string $key, mixed $default_value = null ): mixed;
+}

--- a/src/Interfaces/Settings_Interface.php
+++ b/src/Interfaces/Settings_Interface.php
@@ -2,6 +2,9 @@
 /**
  * Defines the public contract for a settings page builder.
  *
+ * This interface outlines the methods required for a class that fluently
+ * builds and manages a WordPress settings page.
+ *
  * @package WPTechnix\WP_Settings_Builder\Interfaces
  */
 
@@ -17,37 +20,42 @@ use WPTechnix\WP_Settings_Builder\Field_Factory;
  * @phpstan-import-type Supported_Field_Type from Field_Factory
  */
 interface Settings_Interface {
+	/*
+	|--------------------------------------------------------------------------
+	| Page Configuration
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
-	 * Sets the main title of the settings page (the `<h1>` tag).
+	 * Sets the main title of the settings page, typically displayed in an `<h1>` tag.
 	 *
 	 * @param string $page_title The main title for the settings page.
 	 *
 	 * @phpstan-param non-empty-string $page_title
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function set_page_title( string $page_title ): static;
 
 	/**
-	 * Sets the title displayed in the WordPress admin menu.
+	 * Sets the title displayed in the WordPress admin menu for the settings page.
 	 *
 	 * @param string $menu_title The title for the admin menu item.
 	 *
 	 * @phpstan-param non-empty-string $menu_title
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function set_menu_title( string $menu_title ): static;
 
 	/**
-	 * Sets the required capability to view and save the settings page.
+	 * Sets the required WordPress capability to view and save the settings page.
 	 *
 	 * @param string $capability The WordPress capability string (e.g., 'manage_options').
 	 *
 	 * @phpstan-param non-empty-string $capability
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function set_capability( string $capability ): static;
 
@@ -58,26 +66,29 @@ interface Settings_Interface {
 	 *
 	 * @phpstan-param non-empty-string $parent_slug
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function set_parent_slug( string $parent_slug ): static;
 
-
 	/**
-	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
+	 * Sets the HTML class prefix used for custom styling of the settings page elements.
 	 *
-	 * @param string $html_prefix The HTML prefix to use.
+	 * @param string $html_prefix The HTML prefix to use for CSS classes.
 	 *
 	 * @phpstan-param non-empty-string $html_prefix
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function set_html_prefix( string $html_prefix ): static;
 
+	/*
+	|--------------------------------------------------------------------------
+	| Settings Structure Definition
+	|--------------------------------------------------------------------------
+	*/
+
 	/**
-	 * Adds a navigation tab to the settings page.
-	 *
-	 * This automatically enables the tabbed interface.
+	 * Adds a navigation tab to the settings page, enabling a tabbed interface.
 	 *
 	 * @param string      $id    A unique identifier for the tab.
 	 * @param string      $title The visible title of the tab.
@@ -87,41 +98,35 @@ interface Settings_Interface {
 	 * @phpstan-param non-empty-string $title
 	 * @phpstan-param null|non-empty-string $icon
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
 	public function add_tab( string $id, string $title, ?string $icon = null ): static;
 
 	/**
-	 * Adds a settings section to group related fields.
+	 * Adds a settings section to group related fields under a common heading.
 	 *
 	 * @param string      $id          A unique identifier for the section.
-	 * @param string      $title       The visible title of the section (an `<h2>` tag).
+	 * @param string      $title       The visible title of the section.
 	 * @param null|string $description (Optional) A short description displayed below the section title.
-	 * @param null|string $tab_id      (Optional) The ID of the tab this section belongs to. Required for tabbed interfaces.
+	 * @param null|string $tab_id      (Optional) The ID of the tab this section belongs to. This is required for tabbed interfaces.
 	 *
 	 * @phpstan-param non-empty-string $id
 	 * @phpstan-param non-empty-string $title
 	 * @phpstan-param null|non-empty-string $description
 	 * @phpstan-param null|non-empty-string $tab_id
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
-	public function add_section(
-		string $id,
-		string $title,
-		?string $description = null,
-		?string $tab_id = null
-	): static;
+	public function add_section( string $id, string $title, ?string $description = null, ?string $tab_id = null ): static;
 
 	/**
-	 * Adds a setting field to a section.
+	 * Adds a setting field to a specified section.
 	 *
 	 * @param string $id         A unique identifier for the field, used as the key in the options array.
 	 * @param string $section_id The ID of the section this field belongs to.
 	 * @param string $type       The type of field (e.g., 'text', 'toggle', 'select').
-	 * @param string $title      The title displayed for the field.
-	 * @param array  $extras     (Optional) Additional arguments for the field, such as 'default',
-	 *                           description', 'options', 'attributes', etc.
+	 * @param string $title      The label displayed for the field.
+	 * @param array  $extras     (Optional) Additional configuration arguments for the field, such as 'options', 'placeholder', or 'description'.
 	 *
 	 * @phpstan-param non-empty-string $id
 	 * @phpstan-param non-empty-string $section_id
@@ -129,31 +134,32 @@ interface Settings_Interface {
 	 * @phpstan-param non-empty-string $title
 	 * @phpstan-param array<string, mixed> $extras
 	 *
-	 * @return static Provides a fluent interface.
+	 * @return static Provides a fluent interface for method chaining.
 	 */
-	public function add_field(
-		string $id,
-		string $section_id,
-		string $type,
-		string $title,
-		array $extras = []
-	): static;
+	public function add_field( string $id, string $section_id, string $type, string $title, array $extras = [] ): static;
+
+	/*
+	|--------------------------------------------------------------------------
+	| Core Functionality
+	|--------------------------------------------------------------------------
+	*/
 
 	/**
-	 * Hooks the settings framework into the appropriate WordPress actions.
-	 * This method must be called to activate the settings page and make it appear.
+	 * Hooks the settings framework into WordPress to register and render the page.
+	 *
+	 * This method must be called for the settings page to be activated and displayed.
 	 */
 	public function init(): void;
 
 	/**
-	 * Retrieve the setting value for given field key.
+	 * Retrieves a saved setting value from the database.
 	 *
-	 * @param string     $key The specific option key (field ID) to retrieve.
-	 * @param mixed|null $default_value A final fallback value if no saved option or field default is found.
+	 * @param string     $key           The specific option key (field ID) to retrieve.
+	 * @param mixed|null $default_value A final fallback value if no other value is available.
 	 *
 	 * @phpstan-param non-empty-string $key
 	 *
-	 * @return mixed The saved value, the field's default value, or the provided default.
+	 * @return mixed The saved value, the field's default, or the provided default.
 	 */
 	public function get( string $key, mixed $default_value = null ): mixed;
 }

--- a/src/Page_Renderer.php
+++ b/src/Page_Renderer.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Handles all HTML output for the settings page.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+/**
+ * Class responsible for handling all HTML output for the settings page.
+ */
+final class Page_Renderer {
+
+	/**
+	 * Class Constructor
+	 *
+	 * @param null|string $active_tab The currently active tab.
+	 *
+	 * @phpstan-param null|non-empty-string $active_tab
+	 */
+	public function __construct(
+		// @phpstan-ignore-next-line
+		private ?string $active_tab
+	) {}
+
+	/**
+	 * Renders the entire settings page.
+	 *
+	 * This is the main callback function for `add_submenu_page`.
+	 */
+	public function render_page(): void {
+		// TODO: Implement.
+	}
+
+	/**
+	 * The WordPress callback for rendering a settings field.
+	 *
+	 * @param array $args Arguments passed from `add_settings_field`.
+	 * @phpstan-param array<non-empty-string, mixed> $args
+	 */
+	public function render_field( array $args ): void {
+		// TODO: Implement.
+	}
+}

--- a/src/Page_Renderer.php
+++ b/src/Page_Renderer.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 
 namespace WPTechnix\WP_Settings_Builder;
 
+use InvalidArgumentException;
+
 /**
  * Class responsible for handling all HTML output for the settings page.
  */
 final class Page_Renderer {
-
 
 	/**
 	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
@@ -27,9 +28,11 @@ final class Page_Renderer {
 	/**
 	 * Class Constructor
 	 *
+	 * @param Field_Factory  $field_factory Field factory.
 	 * @param Settings_Store $settings_store Settings store.
 	 */
 	public function __construct(
+		private Field_Factory $field_factory,
 		private Settings_Store $settings_store
 	) {}
 
@@ -56,12 +59,7 @@ final class Page_Renderer {
 
 			<?php
 			settings_errors();
-			?>
-
-			<?php
-			if ( $this->settings_store->has_tabs() ) :
-				$this->render_tabs();
-			endif;
+			$this->maybe_render_tabs();
 			?>
 
 			<!--suppress HtmlUnknownTarget -->
@@ -88,17 +86,81 @@ final class Page_Renderer {
 	 * The WordPress callback for rendering a settings field.
 	 *
 	 * @param array $args Arguments passed from `add_settings_field`.
+	 *
 	 * @phpstan-param array<non-empty-string, mixed> $args
 	 */
 	public function render_field( array $args ): void {
-		// TODO: Implement.
+		$field_id = $args['id'] ?? null;
+		if ( empty( $field_id ) || ! is_string( $field_id ) ) {
+			return;
+		}
+
+		$field_config = $this->settings_store->get_field( $field_id );
+
+		if ( empty( $field_config ) ) {
+			return;
+		}
+
+		$field_config['extras']                = $field_config['extras'] ?? [];
+		$field_config['extras']['html_prefix'] = $this->html_prefix;
+
+		try {
+			$field_object = $this->field_factory->create( $field_config['type'], $field_config );
+
+			$value = $this->settings_store->get( $field_id, $field_object->get_default_value() );
+
+			$field_attributes = $field_config['attributes'] ?? [];
+			if ( ! is_array( $field_attributes ) ) {
+				$field_attributes = [];
+			}
+
+			$conditional_attr = '';
+
+			if ( ! empty( $field_config['extras']['conditional'] ) ) {
+				$cond = $field_config['extras']['conditional'];
+				if ( ! is_array( $cond ) ) {
+					$cond = [];
+				}
+
+				$cond_field = $cond['field'] ?? '';
+				$cond_field = is_string( $cond_field ) ? $cond_field : '';
+
+				$cond_value = $cond['value'] ?? '';
+				$cond_value = is_string( $cond_value ) ? $cond_value : '';
+
+				$cond_operator = $cond['operator'] ?? '==';
+				$cond_operator = in_array( $cond_operator, [ '==', '!=', '>', '<', '>=', '<=' ], true ) ? $cond_operator : '==';
+
+				$conditional_attr = sprintf(
+					'data-conditional="%s" data-conditional-value="%s" data-conditional-operator="%s"',
+					esc_attr( $cond_field ),
+					esc_attr( $cond_value ),
+					esc_attr( $cond_operator )
+				);
+			}
+
+			printf( '<div class="%s-field-container" %s>', esc_attr( $this->html_prefix ), $conditional_attr ); // phpcs:ignore WordPress.Security.EscapeOutput
+
+			$field_object->render( $value, $field_attributes );
+
+			if ( ! empty( $field_config['extras']['description'] ) && 'description' !== $field_config['type'] ) {
+				echo '<p class="description">' . wp_kses_post( $field_config['extras']['description'] ) . '</p>';
+			}
+			echo '</div>';
+		} catch ( InvalidArgumentException $e ) {
+			echo '<p><strong>Error:</strong> ' . esc_html( $e->getMessage() ) . '</p>';
+		}
 	}
 
 
 	/**
 	 * Renders the navigation tabs for the settings page.
 	 */
-	private function render_tabs(): void {
+	private function maybe_render_tabs(): void {
+		if ( ! $this->settings_store->has_tabs() ) {
+			return;
+		}
+
 		$classes = implode(
 			' ',
 			[
@@ -108,13 +170,14 @@ final class Page_Renderer {
 		);
 
 		$active_tab = $this->settings_store->get_active_tab();
+		$page_slug  = $this->settings_store->get_page_slug();
 
 		echo '<nav class="' . esc_attr( $classes ) . '">';
 		foreach ( $this->settings_store->get_tabs() as $tab_id => $tab ) {
 			$url   = add_query_arg(
 				[
-					'page' => $this->settings_store->get_page_slug(),
-					'tab'  => $tab_id,
+					'page'       => $page_slug,
+					'active_tab' => $active_tab,
 				]
 			);
 			$class = 'nav-tab' . ( $tab_id === $active_tab ? ' nav-tab-active' : '' );
@@ -139,7 +202,7 @@ final class Page_Renderer {
 
 		$page_slug  = $this->settings_store->get_page_slug();
 		$active_tab = $this->settings_store->get_active_tab();
-		$sections   = $this->settings_store->get_sections();
+		$sections   = $this->settings_store->get_sections( $active_tab );
 
 		if ( empty( $wp_settings_sections[ $page_slug ] ) ) {
 			return;
@@ -151,13 +214,8 @@ final class Page_Renderer {
 				continue;
 			}
 
-			// Check if the section belongs to the currently active tab.
-			if ( $sections[ $section['id'] ]['tab_id'] !== $active_tab ) {
-				continue;
-			}
-
 			if ( $section['title'] ) {
-				echo '<h2>' . esc_html( $section['title'] ) . "</h2>\n";
+				echo '<h2>' . esc_html( $section['title'] ) . '</h2>';
 			}
 
 			if ( $section['callback'] ) {

--- a/src/Page_Renderer.php
+++ b/src/Page_Renderer.php
@@ -14,17 +14,35 @@ namespace WPTechnix\WP_Settings_Builder;
  */
 final class Page_Renderer {
 
+
+	/**
+	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $html_prefix = 'wptechnix-settings';
+
 	/**
 	 * Class Constructor
 	 *
-	 * @param null|string $active_tab The currently active tab.
-	 *
-	 * @phpstan-param null|non-empty-string $active_tab
+	 * @param Settings_Store $settings_store Settings store.
 	 */
 	public function __construct(
-		// @phpstan-ignore-next-line
-		private ?string $active_tab
+		private Settings_Store $settings_store
 	) {}
+
+	/**
+	 * Set HTML prefix that will be used in fields markup.
+	 *
+	 * @param string $html_prefix HTML prefix.
+	 *
+	 * @phpstan-param non-empty-string $html_prefix
+	 */
+	public function set_html_prefix( string $html_prefix ): void {
+		$this->html_prefix = $html_prefix;
+	}
 
 	/**
 	 * Renders the entire settings page.
@@ -32,7 +50,38 @@ final class Page_Renderer {
 	 * This is the main callback function for `add_submenu_page`.
 	 */
 	public function render_page(): void {
-		// TODO: Implement.
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<?php
+			settings_errors();
+			?>
+
+			<?php
+			if ( $this->settings_store->has_tabs() ) :
+				$this->render_tabs();
+			endif;
+			?>
+
+			<!--suppress HtmlUnknownTarget -->
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( $this->settings_store->get_option_group_name() );
+
+				if ( $this->settings_store->has_tabs() ) {
+					$active_tab = $this->settings_store->get_active_tab();
+					printf( '<input type="hidden" name="tab" value="%s" />', esc_attr( (string) $active_tab ) );
+					$this->render_sections();
+				} else {
+					do_settings_sections( $this->settings_store->get_page_slug() );
+				}
+
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
 	}
 
 	/**
@@ -43,5 +92,83 @@ final class Page_Renderer {
 	 */
 	public function render_field( array $args ): void {
 		// TODO: Implement.
+	}
+
+
+	/**
+	 * Renders the navigation tabs for the settings page.
+	 */
+	private function render_tabs(): void {
+		$classes = implode(
+			' ',
+			[
+				'nav-tab-wrapper',
+				$this->html_prefix . '-nav-tab-wrapper',
+			]
+		);
+
+		$active_tab = $this->settings_store->get_active_tab();
+
+		echo '<nav class="' . esc_attr( $classes ) . '">';
+		foreach ( $this->settings_store->get_tabs() as $tab_id => $tab ) {
+			$url   = add_query_arg(
+				[
+					'page' => $this->settings_store->get_page_slug(),
+					'tab'  => $tab_id,
+				]
+			);
+			$class = 'nav-tab' . ( $tab_id === $active_tab ? ' nav-tab-active' : '' );
+			$icon  = ! empty( $tab['icon'] ) ? '<span class="dashicons ' . esc_attr( $tab['icon'] ) . '"></span>' : '';
+			printf(
+				'<a href="%s" class="%s">%s%s</a>',
+				esc_url( $url ),
+				esc_attr( $class ),
+				$icon, // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_html( $tab['title'] )
+			);
+		}
+		echo '</nav>';
+	}
+
+
+	/**
+	 * Renders all settings sections associated with the active tab.
+	 */
+	private function render_sections(): void {
+		global $wp_settings_sections, $wp_settings_fields;
+
+		$page_slug  = $this->settings_store->get_page_slug();
+		$active_tab = $this->settings_store->get_active_tab();
+		$sections   = $this->settings_store->get_sections();
+
+		if ( empty( $wp_settings_sections[ $page_slug ] ) ) {
+			return;
+		}
+
+		foreach ( (array) $wp_settings_sections[ $page_slug ] as $section ) {
+			// Ensure the section ID exists in our store before proceeding.
+			if ( ! isset( $sections[ $section['id'] ] ) ) {
+				continue;
+			}
+
+			// Check if the section belongs to the currently active tab.
+			if ( $sections[ $section['id'] ]['tab_id'] !== $active_tab ) {
+				continue;
+			}
+
+			if ( $section['title'] ) {
+				echo '<h2>' . esc_html( $section['title'] ) . "</h2>\n";
+			}
+
+			if ( $section['callback'] ) {
+				call_user_func( $section['callback'], $section );
+			}
+
+			if ( ! empty( $wp_settings_fields[ $page_slug ][ $section['id'] ] ) ) {
+				echo '<table class="form-table" role="presentation">';
+				do_settings_fields( $page_slug, $section['id'] );
+				echo '</table>';
+			}
+		}
 	}
 }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Sanitizes settings before they are saved to the database.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+/**
+ * Sanitizes settings before they are saved to the database.
+ */
+final class Sanitizer {
+
+	/**
+	 * Class Constructor
+	 *
+	 * @param null|string $active_tab The currently active tab.
+	 *
+	 * @phpstan-param null|non-empty-string $active_tab
+	 */
+	public function __construct(
+		// @phpstan-ignore-next-line
+		private ?string $active_tab
+	) {}
+
+	/**
+	 * Sanitizes the settings array.
+	 *
+	 * This is the main callback for the 'sanitize_callback' argument in
+	 * `register_setting`. It processes the raw input from the $_POST array.
+	 *
+	 * @param mixed $input The raw input from the form submission (from `$_POST`).
+	 *
+	 * @return array<string, mixed> The complete, sanitized settings array ready for saving.
+	 */
+	public function sanitize( mixed $input ): array {
+		// TODO: Implement sanitization logic.
+		if ( ! is_array( $input ) ) {
+			return [];
+		}
+		return $input;
+	}
+}

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -17,13 +17,11 @@ final class Sanitizer {
 	/**
 	 * Class Constructor
 	 *
-	 * @param null|string $active_tab The currently active tab.
-	 *
-	 * @phpstan-param null|non-empty-string $active_tab
+	 * @param Settings_Store $settings_store Settings Store.
 	 */
 	public function __construct(
 		// @phpstan-ignore-next-line
-		private ?string $active_tab
+		private Settings_Store $settings_store
 	) {}
 
 	/**

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -32,7 +32,9 @@ final class Sanitizer {
 	 *
 	 * @param mixed $input The raw input from the form submission (from `$_POST`).
 	 *
-	 * @return array<string, mixed> The complete, sanitized settings array ready for saving.
+	 * @return array The complete, sanitized settings array ready for saving.
+	 *
+	 * @phpstan-return array<string, mixed>
 	 */
 	public function sanitize( mixed $input ): array {
 		// TODO: Implement sanitization logic.

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,480 @@
+<?php
+/**
+ * A fluent builder for creating and managing WordPress admin settings pages.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+use InvalidArgumentException;
+use WPTechnix\WP_Settings_Builder\Interfaces\Settings_Interface;
+
+/**
+ * A fluent builder for creating and managing WordPress admin settings pages.
+ *
+ * @phpstan-import-type Field_Config from Field_Factory
+ *
+ * @phpstan-type Section_Config array{
+ *   title: non-empty-string,
+ *   description: null|non-empty-string,
+ * }
+ *
+ * @phpstan-type Tab_Config array{
+ *   title: non-empty-string,
+ *   icon: null|non-empty-string
+ * }
+ *
+ * @phpstan-type Fields_Config array<non-empty-string,Field_Config>
+ * @phpstan-type Sections_Config array<non-empty-string,Section_Config>
+ * @phpstan-type Tabs_Config array<non-empty-string,Tab_Config>
+ */
+final class Settings implements Settings_Interface {
+
+	/**
+	 * Instance of the factory responsible for creating field objects.
+	 *
+	 * @var Field_Factory
+	 */
+	private Field_Factory $field_factory;
+
+	/**
+	 * Store for retrieving settings data.
+	 *
+	 * @var Settings_Store
+	 */
+	private Settings_Store $settings_store;
+
+	/**
+	 * Instance of the asset manager responsible for enqueuing scripts and styles.
+	 *
+	 * @var Asset_Manager
+	 */
+	private Asset_Manager $asset_manager;
+
+	/**
+	 * Instance of the page renderer responsible for rendering the settings page.
+	 *
+	 * @var Page_Renderer
+	 */
+	private Page_Renderer $page_renderer;
+
+	/**
+	 * Sanitizer instance.
+	 *
+	 * @var Sanitizer
+	 */
+	private Sanitizer $sanitizer;
+
+	/**
+	 * Page Title
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $page_title;
+
+	/**
+	 * Menu Title
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $menu_title;
+
+	/**
+	 * Capability required to access the settings page.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $capability = 'manage_options';
+
+	/**
+	 * Parent slug for the submenu page.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $parent_slug = 'options-general.php';
+
+	/**
+	 * Active tab ID.
+	 *
+	 * @var null|string
+	 *
+	 * @phpstan-var null|non-empty-string
+	 */
+	private null|string $active_tab = null;
+
+	/**
+	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $html_prefix = 'wptechnix-settings';
+
+	/**
+	 * Query argument for tab selection.
+	 *
+	 * @var string
+	 *
+	 * @phpstan-var non-empty-string
+	 */
+	private string $tab_query_arg = 'tab';
+
+	/**
+	 * Tabs configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Tabs_Config
+	 */
+	private array $tabs = [];
+
+	/**
+	 * Sections configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Sections_Config
+	 */
+	private array $sections = [];
+
+	/**
+	 * Fields configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Fields_Config
+	 */
+	private array $fields = [];
+
+	/**
+	 * Settings constructor.
+	 *
+	 * Initializes the settings framework with essential parameters and default configurations.
+	 *
+	 * @param string $option_name The name of the option to be stored in the wp_options table.
+	 * @param string $page_slug   The unique slug for the settings page URL.
+	 *
+	 * @phpstan-param non-empty-string $option_name
+	 * @phpstan-param non-empty-string $page_slug
+	 *
+	 * @throws InvalidArgumentException If option_name or page_slug are empty.
+	 */
+	public function __construct(
+		private string $option_name,
+		private string $page_slug
+	) {
+		if ( empty( $this->option_name ) ) {
+			throw new InvalidArgumentException( 'Option name cannot be empty.' );
+		}
+
+		if ( empty( $this->page_slug ) ) {
+			throw new InvalidArgumentException( 'Page slug cannot be empty.' );
+		}
+
+		$default_page_title = __( 'Settings', 'default' );
+
+		/** @phpstan-var non-empty-string $default_page_title */
+
+		$this->page_title = $default_page_title;
+		$this->menu_title = $this->page_title;
+
+		$this->determine_active_tab();
+
+		$this->settings_store = new Settings_Store( $this->option_name );
+		$this->field_factory  = new Field_Factory();
+		$this->asset_manager  = new Asset_Manager( $this->html_prefix );
+		$this->page_renderer  = new Page_Renderer( $this->active_tab );
+		$this->sanitizer      = new Sanitizer( $this->active_tab );
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Setters
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Sets the page title.
+	 *
+	 * @param string $page_title The page title.
+	 *
+	 * @phpstan-param non-empty-string $page_title
+	 *
+	 * @return self
+	 */
+	public function set_page_title( string $page_title ): self {
+		$this->page_title = $page_title;
+		return $this;
+	}
+
+	/**
+	 * Sets the menu title.
+	 *
+	 * @param string $menu_title The menu title.
+	 *
+	 * @phpstan-param non-empty-string $menu_title
+	 *
+	 * @return self
+	 */
+	public function set_menu_title( string $menu_title ): self {
+		$this->menu_title = $menu_title;
+		return $this;
+	}
+
+	/**
+	 * Sets the capability required to access the settings page.
+	 *
+	 * @param string $capability The capability.
+	 *
+	 * @phpstan-param non-empty-string $capability
+	 *
+	 * @return self
+	 */
+	public function set_capability( string $capability ): self {
+		$this->capability = $capability;
+		return $this;
+	}
+
+	/**
+	 * Sets the parent slug for the submenu page.
+	 *
+	 * @param string $parent_slug The parent slug.
+	 *
+	 * @phpstan-param non-empty-string $parent_slug
+	 *
+	 * @return self
+	 */
+	public function set_parent_slug( string $parent_slug ): self {
+		$this->parent_slug = $parent_slug;
+		return $this;
+	}
+
+	/**
+	 * Sets the HTML prefix for the settings page.
+	 *
+	 * @param string $html_prefix The HTML prefix.
+	 *
+	 * @phpstan-param non-empty-string $html_prefix
+	 *
+	 * @return self
+	 */
+	public function set_html_prefix( string $html_prefix ): self {
+		$this->html_prefix = $html_prefix;
+		return $this;
+	}
+
+	/**
+	 * Sets the query argument for tab selection.
+	 *
+	 * @param string $tab_query_arg The query argument.
+	 * @phpstan-param non-empty-string $tab_query_arg
+	 * @return self
+	 */
+	public function set_tab_query_arg( string $tab_query_arg ): self {
+		$this->tab_query_arg = $tab_query_arg;
+		return $this;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Core Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Initializes the settings page by hooking into WordPress actions.
+	 */
+	public function init(): void {
+		add_action( 'admin_menu', [ $this, 'register_page' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_enqueue_scripts', [ $this->asset_manager, 'enqueue' ] );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function add_tab( string $id, string $title, ?string $icon = null ): self {
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		$this->tabs[ $id ] = [
+			'title' => $title,
+			'icon'  => $icon,
+		];
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function add_section(
+		string $id,
+		string $title,
+		?string $description = null,
+		?string $tab_id = null
+	): self {
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		$this->sections[ $id ] = [
+			'title'       => $title,
+			'description' => $description,
+			'tab_id'      => $tab_id,
+		];
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws InvalidArgumentException When unsupported field type or non-existing section is provided
+	 */
+	public function add_field(
+		string $id,
+		string $section_id,
+		string $type,
+		string $title,
+		array $extras = []
+	): self {
+
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		if ( ! isset( $this->sections[ $section_id ] ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Section "%s" must be added before adding fields to it.',
+					$section_id
+				)
+			);
+		}
+
+		$supported_types = $this->field_factory->get_supported_types();
+
+		if ( ! in_array( $type, $supported_types, true ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Unsupported field type: "%s". Supported types are: "%s"',
+					$type,
+					implode( '", "', $supported_types )
+				)
+			);
+		}
+
+		$field_config = [
+			'id'      => $id,
+			'name'    => $this->option_name . '[' . $id . ']',
+			'section' => $section_id,
+			'type'    => $type,
+			'title'   => $title,
+			'extras'  => $extras,
+		];
+
+		$this->fields[ $id ] = $field_config;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get( string $key, mixed $default_value = null ): mixed {
+		return $this->settings_store->get( $key, $default_value );
+	}
+
+	/**
+	 * Registers the settings page with the WordPress admin menu.
+	 *
+	 * @internal This method is a callback for the 'admin_menu' hook and should not be called directly.
+	 */
+	public function register_page(): void {
+		add_submenu_page(
+			$this->parent_slug,
+			$this->page_title,
+			$this->menu_title,
+			$this->capability,
+			$this->page_slug,
+			[ $this->page_renderer, 'render_page' ],
+			null
+		);
+	}
+
+	/**
+	 * Registers the settings, sections, and fields with the WordPress Settings API.
+	 *
+	 * @internal This method is a callback for the 'admin_init' hook and should not be called directly.
+	 */
+	public function register_settings(): void {
+
+		register_setting(
+			$this->option_name,
+			$this->option_name,
+			[ 'sanitize_callback' => [ $this->sanitizer, 'sanitize' ] ]
+		);
+
+		foreach ( $this->sections as $id => $section ) {
+			add_settings_section(
+				$id,
+				$section['title'],
+				! empty( $section['description'] )
+					? function () use ( $section ) {
+						echo '<p class="description">' . esc_html( $section['description'] ) . '</p>';
+					}
+					: '__return_false',
+				$this->page_slug
+			);
+		}
+
+		foreach ( $this->fields as $id => $field ) {
+			$args = $field;
+
+			if ( in_array( $field['type'], $this->field_factory->get_text_types(), true ) ) {
+				$args['label_for'] = $id;
+			}
+
+			add_settings_field(
+				$id,
+				$field['title'],
+				[ $this->page_renderer, 'render_field' ],
+				$this->page_slug,
+				$field['section'],
+				$args
+			);
+		}
+	}
+
+	/**
+	 * Determines the active tab and stores it in the class property.
+	 */
+	private function determine_active_tab(): void {
+		if ( empty( $this->tabs ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$active_tab = sanitize_key( $_REQUEST[ $this->tab_query_arg ] ?? '' );
+
+		if ( empty( $active_tab ) || ! isset( $this->tabs[ $active_tab ] ) ) {
+			$active_tab = (string) array_key_first( $this->tabs );
+		}
+
+		$this->active_tab = $active_tab;
+	}
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -124,7 +124,7 @@ final class Settings implements Settings_Interface {
 		$this->field_factory  = new Field_Factory();
 		$this->settings_store = new Settings_Store( $this->field_factory, $this->option_name, $this->page_slug );
 		$this->asset_manager  = new Asset_Manager();
-		$this->page_renderer  = new Page_Renderer( $this->settings_store );
+		$this->page_renderer  = new Page_Renderer( $this->field_factory, $this->settings_store );
 		$this->sanitizer      = new Sanitizer( $this->settings_store );
 	}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -15,21 +15,7 @@ use WPTechnix\WP_Settings_Builder\Interfaces\Settings_Interface;
 /**
  * A fluent builder for creating and managing WordPress admin settings pages.
  *
- * @phpstan-import-type Field_Config from Field_Factory
- *
- * @phpstan-type Section_Config array{
- *   title: non-empty-string,
- *   description: null|non-empty-string,
- * }
- *
- * @phpstan-type Tab_Config array{
- *   title: non-empty-string,
- *   icon: null|non-empty-string
- * }
- *
- * @phpstan-type Fields_Config array<non-empty-string,Field_Config>
- * @phpstan-type Sections_Config array<non-empty-string,Section_Config>
- * @phpstan-type Tabs_Config array<non-empty-string,Tab_Config>
+ * @phpstan-import-type Supported_Field_Type from Field_Factory
  */
 final class Settings implements Settings_Interface {
 
@@ -105,60 +91,6 @@ final class Settings implements Settings_Interface {
 	private string $parent_slug = 'options-general.php';
 
 	/**
-	 * Active tab ID.
-	 *
-	 * @var null|string
-	 *
-	 * @phpstan-var null|non-empty-string
-	 */
-	private null|string $active_tab = null;
-
-	/**
-	 * The HTML prefix that will be used in fields markup and generated CSS/JS.
-	 *
-	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	private string $html_prefix = 'wptechnix-settings';
-
-	/**
-	 * Query argument for tab selection.
-	 *
-	 * @var string
-	 *
-	 * @phpstan-var non-empty-string
-	 */
-	private string $tab_query_arg = 'tab';
-
-	/**
-	 * Tabs configuration.
-	 *
-	 * @var array
-	 *
-	 * @phpstan-var Tabs_Config
-	 */
-	private array $tabs = [];
-
-	/**
-	 * Sections configuration.
-	 *
-	 * @var array
-	 *
-	 * @phpstan-var Sections_Config
-	 */
-	private array $sections = [];
-
-	/**
-	 * Fields configuration.
-	 *
-	 * @var array
-	 *
-	 * @phpstan-var Fields_Config
-	 */
-	private array $fields = [];
-
-	/**
 	 * Settings constructor.
 	 *
 	 * Initializes the settings framework with essential parameters and default configurations.
@@ -186,17 +118,14 @@ final class Settings implements Settings_Interface {
 		$default_page_title = __( 'Settings', 'default' );
 
 		/** @phpstan-var non-empty-string $default_page_title */
-
 		$this->page_title = $default_page_title;
 		$this->menu_title = $this->page_title;
 
-		$this->determine_active_tab();
-
-		$this->settings_store = new Settings_Store( $this->option_name );
 		$this->field_factory  = new Field_Factory();
-		$this->asset_manager  = new Asset_Manager( $this->html_prefix );
-		$this->page_renderer  = new Page_Renderer( $this->active_tab );
-		$this->sanitizer      = new Sanitizer( $this->active_tab );
+		$this->settings_store = new Settings_Store( $this->field_factory, $this->option_name, $this->page_slug );
+		$this->asset_manager  = new Asset_Manager();
+		$this->page_renderer  = new Page_Renderer( $this->settings_store );
+		$this->sanitizer      = new Sanitizer( $this->settings_store );
 	}
 
 	/*
@@ -206,13 +135,7 @@ final class Settings implements Settings_Interface {
 	*/
 
 	/**
-	 * Sets the page title.
-	 *
-	 * @param string $page_title The page title.
-	 *
-	 * @phpstan-param non-empty-string $page_title
-	 *
-	 * @return self
+	 * {@inheritDoc}
 	 */
 	public function set_page_title( string $page_title ): self {
 		$this->page_title = $page_title;
@@ -220,13 +143,7 @@ final class Settings implements Settings_Interface {
 	}
 
 	/**
-	 * Sets the menu title.
-	 *
-	 * @param string $menu_title The menu title.
-	 *
-	 * @phpstan-param non-empty-string $menu_title
-	 *
-	 * @return self
+	 * {@inheritDoc}
 	 */
 	public function set_menu_title( string $menu_title ): self {
 		$this->menu_title = $menu_title;
@@ -234,13 +151,7 @@ final class Settings implements Settings_Interface {
 	}
 
 	/**
-	 * Sets the capability required to access the settings page.
-	 *
-	 * @param string $capability The capability.
-	 *
-	 * @phpstan-param non-empty-string $capability
-	 *
-	 * @return self
+	 * {@inheritDoc}
 	 */
 	public function set_capability( string $capability ): self {
 		$this->capability = $capability;
@@ -248,13 +159,7 @@ final class Settings implements Settings_Interface {
 	}
 
 	/**
-	 * Sets the parent slug for the submenu page.
-	 *
-	 * @param string $parent_slug The parent slug.
-	 *
-	 * @phpstan-param non-empty-string $parent_slug
-	 *
-	 * @return self
+	 * {@inheritDoc}
 	 */
 	public function set_parent_slug( string $parent_slug ): self {
 		$this->parent_slug = $parent_slug;
@@ -262,28 +167,41 @@ final class Settings implements Settings_Interface {
 	}
 
 	/**
-	 * Sets the HTML prefix for the settings page.
-	 *
-	 * @param string $html_prefix The HTML prefix.
-	 *
-	 * @phpstan-param non-empty-string $html_prefix
-	 *
-	 * @return self
+	 * {@inheritDoc}
 	 */
 	public function set_html_prefix( string $html_prefix ): self {
-		$this->html_prefix = $html_prefix;
+		$this->asset_manager->set_html_prefix( $html_prefix );
+		$this->page_renderer->set_html_prefix( $html_prefix );
+		return $this;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Fluent Configuration Methods
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function add_tab( string $id, string $title, ?string $icon = null ): self {
+		$this->settings_store->add_tab( $id, $title, $icon );
 		return $this;
 	}
 
 	/**
-	 * Sets the query argument for tab selection.
-	 *
-	 * @param string $tab_query_arg The query argument.
-	 * @phpstan-param non-empty-string $tab_query_arg
-	 * @return self
+	 * {@inheritDoc}
 	 */
-	public function set_tab_query_arg( string $tab_query_arg ): self {
-		$this->tab_query_arg = $tab_query_arg;
+	public function add_section( string $id, string $title, ?string $description = null, ?string $tab_id = null ): self {
+		$this->settings_store->add_section( $id, $title, $description, $tab_id );
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function add_field( string $id, string $section_id, string $type, string $title, array $extras = [] ): self {
+		$this->settings_store->add_field( $id, $section_id, $type, $title, $extras );
 		return $this;
 	}
 
@@ -294,102 +212,12 @@ final class Settings implements Settings_Interface {
 	*/
 
 	/**
-	 * Initializes the settings page by hooking into WordPress actions.
+	 * {@inheritDoc}
 	 */
 	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'register_page' ] );
 		add_action( 'admin_init', [ $this, 'register_settings' ] );
 		add_action( 'admin_enqueue_scripts', [ $this->asset_manager, 'enqueue' ] );
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function add_tab( string $id, string $title, ?string $icon = null ): self {
-		$id = sanitize_key( $id );
-
-		/** @phpstan-var non-empty-string $id */
-
-		$this->tabs[ $id ] = [
-			'title' => $title,
-			'icon'  => $icon,
-		];
-
-		return $this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function add_section(
-		string $id,
-		string $title,
-		?string $description = null,
-		?string $tab_id = null
-	): self {
-		$id = sanitize_key( $id );
-
-		/** @phpstan-var non-empty-string $id */
-
-		$this->sections[ $id ] = [
-			'title'       => $title,
-			'description' => $description,
-			'tab_id'      => $tab_id,
-		];
-
-		return $this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @throws InvalidArgumentException When unsupported field type or non-existing section is provided
-	 */
-	public function add_field(
-		string $id,
-		string $section_id,
-		string $type,
-		string $title,
-		array $extras = []
-	): self {
-
-		$id = sanitize_key( $id );
-
-		/** @phpstan-var non-empty-string $id */
-
-		if ( ! isset( $this->sections[ $section_id ] ) ) {
-			throw new InvalidArgumentException(
-				sprintf(
-					'Section "%s" must be added before adding fields to it.',
-					$section_id
-				)
-			);
-		}
-
-		$supported_types = $this->field_factory->get_supported_types();
-
-		if ( ! in_array( $type, $supported_types, true ) ) {
-			throw new InvalidArgumentException(
-				sprintf(
-					'Unsupported field type: "%s". Supported types are: "%s"',
-					$type,
-					implode( '", "', $supported_types )
-				)
-			);
-		}
-
-		$field_config = [
-			'id'      => $id,
-			'name'    => $this->option_name . '[' . $id . ']',
-			'section' => $section_id,
-			'type'    => $type,
-			'title'   => $title,
-			'extras'  => $extras,
-		];
-
-		$this->fields[ $id ] = $field_config;
-
-		return $this;
 	}
 
 	/**
@@ -411,8 +239,7 @@ final class Settings implements Settings_Interface {
 			$this->menu_title,
 			$this->capability,
 			$this->page_slug,
-			[ $this->page_renderer, 'render_page' ],
-			null
+			[ $this->page_renderer, 'render_page' ]
 		);
 	}
 
@@ -422,19 +249,18 @@ final class Settings implements Settings_Interface {
 	 * @internal This method is a callback for the 'admin_init' hook and should not be called directly.
 	 */
 	public function register_settings(): void {
-
 		register_setting(
-			$this->option_name,
+			$this->settings_store->get_option_group_name(),
 			$this->option_name,
 			[ 'sanitize_callback' => [ $this->sanitizer, 'sanitize' ] ]
 		);
 
-		foreach ( $this->sections as $id => $section ) {
+		foreach ( $this->settings_store->get_sections() as $id => $section ) {
 			add_settings_section(
 				$id,
 				$section['title'],
 				! empty( $section['description'] )
-					? function () use ( $section ) {
+					? static function () use ( $section ) {
 						echo '<p class="description">' . esc_html( $section['description'] ) . '</p>';
 					}
 					: '__return_false',
@@ -442,7 +268,7 @@ final class Settings implements Settings_Interface {
 			);
 		}
 
-		foreach ( $this->fields as $id => $field ) {
+		foreach ( $this->settings_store->get_fields() as $id => $field ) {
 			$args = $field;
 
 			if ( in_array( $field['type'], $this->field_factory->get_text_types(), true ) ) {
@@ -458,23 +284,5 @@ final class Settings implements Settings_Interface {
 				$args
 			);
 		}
-	}
-
-	/**
-	 * Determines the active tab and stores it in the class property.
-	 */
-	private function determine_active_tab(): void {
-		if ( empty( $this->tabs ) ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$active_tab = sanitize_key( $_REQUEST[ $this->tab_query_arg ] ?? '' );
-
-		if ( empty( $active_tab ) || ! isset( $this->tabs[ $active_tab ] ) ) {
-			$active_tab = (string) array_key_first( $this->tabs );
-		}
-
-		$this->active_tab = $active_tab;
 	}
 }

--- a/src/Settings_Store.php
+++ b/src/Settings_Store.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Responsible for storing and retrieving settings data.
+ *
+ * @package WPTechnix\WP_Settings_Builder
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder;
+
+/**
+ * Stores and retrieves settings data.
+ */
+class Settings_Store {
+
+	/**
+	 * Saved settings data.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var array<string, mixed>
+	 */
+	protected array $saved_settings = [];
+
+	/**
+	 * Class Constructor
+	 *
+	 * @param string $option_name WP Option that store the settings.
+	 *
+	 * @phpstan-param non-empty-string $option_name
+	 */
+	public function __construct(
+		protected string $option_name
+	) {}
+
+	/**
+	 * Gets a saved option value from the database.
+	 *
+	 * This is the primary method for retrieving a field's current value for rendering.
+	 * It intelligently falls back to the field's configured 'default' value if no
+	 * saved value exists in the database.
+	 *
+	 * @param string     $key The specific option key (field ID) to retrieve.
+	 * @param mixed|null $default_value A final fallback value if no saved option or field default is found.
+	 *
+	 * @phpstan-param non-empty-string $key
+	 *
+	 * @return mixed The saved value, the field's default value, or the provided default.
+	 */
+	public function get( string $key, mixed $default_value = null ): mixed {
+		$this->fetch_settings();
+		if ( array_key_exists( $key, $this->saved_settings ) ) {
+			return $this->saved_settings[ $key ];
+		}
+
+		return $default_value;
+	}
+
+	/**
+	 * Fetch the stored settings from option.
+	 *
+	 * @param bool $force Force fetch.
+	 */
+	public function fetch_settings( bool $force = false ): void {
+		if ( ! isset( $this->saved_settings ) || $force ) {
+			$settings_from_db     = get_option( $this->option_name, [] );
+			$this->saved_settings = is_array( $settings_from_db ) ? $settings_from_db : [];
+		}
+	}
+
+	/**
+	 * Get option name.
+	 *
+	 * @return string
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_option_name(): string {
+		return $this->option_name;
+	}
+}

--- a/src/Settings_Store.php
+++ b/src/Settings_Store.php
@@ -111,7 +111,7 @@ final class Settings_Store {
 	 */
 	public function get( string $key, mixed $default_value = null ): mixed {
 		$this->fetch_settings();
-		if ( array_key_exists( $key, $this->saved_settings ) ) {
+		if ( isset( $this->saved_settings[ $key ] ) ) {
 			return $this->saved_settings[ $key ];
 		}
 
@@ -362,5 +362,20 @@ final class Settings_Store {
 			$this->fields,
 			static fn( $field ) => $field['section'] === $section_id
 		);
+	}
+
+	/**
+	 * Get the setting field.
+	 *
+	 * @param string $field_id The field ID to retrieve.
+	 *
+	 * @phpstan-param non-empty-string $field_id
+	 *
+	 * @return null|array
+	 *
+	 * @phpstan-return null|Field_Config
+	 */
+	public function get_field( string $field_id ): ?array {
+		return $this->fields[ $field_id ] ?? null;
 	}
 }

--- a/src/Settings_Store.php
+++ b/src/Settings_Store.php
@@ -9,10 +9,66 @@ declare(strict_types=1);
 
 namespace WPTechnix\WP_Settings_Builder;
 
+use InvalidArgumentException;
+
 /**
  * Stores and retrieves settings data.
+ *
+ * @phpstan-import-type Supported_Field_Type from Field_Factory
+ * @phpstan-import-type Field_Config from Field_Factory
+ *
+ * @phpstan-type Section_Config array{
+ *   title: non-empty-string,
+ *   description: null|non-empty-string,
+ *   tab_id: null|non-empty-string,
+ * }
+ *
+ * @phpstan-type Tab_Config array{
+ *   title: non-empty-string,
+ *   icon: null|non-empty-string
+ * }
+ *
+ * @phpstan-type Fields_Config array<non-empty-string,Field_Config>
+ * @phpstan-type Sections_Config array<non-empty-string,Section_Config>
+ * @phpstan-type Tabs_Config array<non-empty-string,Tab_Config>
  */
-class Settings_Store {
+final class Settings_Store {
+
+	/**
+	 * Tabs configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Tabs_Config
+	 */
+	private array $tabs = [];
+
+	/**
+	 * Sections configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Sections_Config
+	 */
+	private array $sections = [];
+
+	/**
+	 * Fields configuration.
+	 *
+	 * @var array
+	 *
+	 * @phpstan-var Fields_Config
+	 */
+	private array $fields = [];
+
+	/**
+	 * Active tab
+	 *
+	 * @var null|string
+	 *
+	 * @phpstan-var null|non-empty-string
+	 */
+	private ?string $active_tab = null;
 
 	/**
 	 * Saved settings data.
@@ -21,17 +77,22 @@ class Settings_Store {
 	 *
 	 * @phpstan-var array<string, mixed>
 	 */
-	protected array $saved_settings = [];
+	private array $saved_settings = [];
 
 	/**
 	 * Class Constructor
 	 *
-	 * @param string $option_name WP Option that store the settings.
+	 * @param Field_Factory $field_factory Field factory.
+	 * @param string        $option_name   WP Option that store the settings.
+	 * @param string        $page_slug     Admin page slug.
 	 *
 	 * @phpstan-param non-empty-string $option_name
+	 * @phpstan-param non-empty-string $page_slug
 	 */
 	public function __construct(
-		protected string $option_name
+		private Field_Factory $field_factory,
+		private string $option_name,
+		private string $page_slug,
 	) {}
 
 	/**
@@ -63,10 +124,20 @@ class Settings_Store {
 	 * @param bool $force Force fetch.
 	 */
 	public function fetch_settings( bool $force = false ): void {
-		if ( ! isset( $this->saved_settings ) || $force ) {
+		if ( empty( $this->saved_settings ) || $force ) {
 			$settings_from_db     = get_option( $this->option_name, [] );
 			$this->saved_settings = is_array( $settings_from_db ) ? $settings_from_db : [];
 		}
+	}
+
+	/**
+	 * Get Page Slug
+	 *
+	 * @return string
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_page_slug(): string {
+		return $this->page_slug;
 	}
 
 	/**
@@ -77,5 +148,219 @@ class Settings_Store {
 	 */
 	public function get_option_name(): string {
 		return $this->option_name;
+	}
+
+
+	/**
+	 * Determines the active tab and stores it in the class property.
+	 *
+	 * @return null|string
+	 *
+	 * @phpstan-return null|non-empty-string
+	 */
+	public function get_active_tab(): ?string {
+
+		if ( isset( $this->active_tab ) ) {
+			return $this->active_tab;
+		}
+
+		if ( empty( $this->tabs ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$active_tab = sanitize_key( $_REQUEST['tab'] ?? '' );
+
+		if ( empty( $active_tab ) || ! isset( $this->tabs[ $active_tab ] ) ) {
+			$active_tab = array_key_first( $this->tabs );
+		}
+
+		$this->active_tab = empty( $active_tab ) ? null : (string) $active_tab;
+
+		return $this->active_tab;
+	}
+
+	/**
+	 * Get option group name.
+	 *
+	 * @return string
+	 * @phpstan-return non-empty-string
+	 */
+	public function get_option_group_name(): string {
+		return $this->option_name . '_group';
+	}
+
+	/**
+	 * Adds a navigation tab to the settings page.
+	 *
+	 * This automatically enables the tabbed interface.
+	 *
+	 * @param string      $id    A unique identifier for the tab.
+	 * @param string      $title The visible title of the tab.
+	 * @param null|string $icon  (Optional) A Dashicons class for an icon (e.g., 'dashicons-admin-generic').
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param null|non-empty-string $icon
+	 */
+	public function add_tab( string $id, string $title, ?string $icon = null ): void {
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		$this->tabs[ $id ] = [
+			'title' => $title,
+			'icon'  => $icon,
+		];
+	}
+
+	/**
+	 * Adds a settings section to group related fields.
+	 *
+	 * @param string      $id          A unique identifier for the section.
+	 * @param string      $title       The visible title of the section (an `<h2>` tag).
+	 * @param null|string $description (Optional) A short description displayed below the section title.
+	 * @param null|string $tab_id      (Optional) The ID of the tab this section belongs to. Required for tabbed interfaces.
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param null|non-empty-string $description
+	 * @phpstan-param null|non-empty-string $tab_id
+	 */
+	public function add_section(
+		string $id,
+		string $title,
+		?string $description = null,
+		?string $tab_id = null
+	): void {
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		$this->sections[ $id ] = [
+			'title'       => $title,
+			'description' => $description,
+			'tab_id'      => $tab_id,
+		];
+	}
+
+	/**
+	 * Adds a setting field to a section.
+	 *
+	 * @param string $id         A unique identifier for the field, used as the key in the options array.
+	 * @param string $section_id The ID of the section this field belongs to.
+	 * @param string $type       The type of field (e.g., 'text', 'toggle', 'select').
+	 * @param string $title      The title displayed for the field.
+	 * @param array  $extras     (Optional) Additional arguments for the field.
+	 *
+	 * @phpstan-param non-empty-string $id
+	 * @phpstan-param non-empty-string $section_id
+	 * @phpstan-param Supported_Field_Type $type
+	 * @phpstan-param non-empty-string $title
+	 * @phpstan-param array<string, mixed> $extras
+	 *
+	 * @throws InvalidArgumentException When invalid field type or non-existent section is provided.
+	 */
+	public function add_field( string $id, string $section_id, string $type, string $title, array $extras = [] ): void {
+
+		$id = sanitize_key( $id );
+
+		/** @phpstan-var non-empty-string $id */
+
+		if ( ! isset( $this->sections[ $section_id ] ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Section "%s" must be added before adding fields to it.',
+					$section_id
+				)
+			);
+		}
+
+		$supported_types = $this->field_factory->get_supported_types();
+
+		if ( ! in_array( $type, $supported_types, true ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Unsupported field type: "%s". Supported types are: "%s"',
+					$type,
+					implode( '", "', $supported_types )
+				)
+			);
+		}
+
+		$field_config = [
+			'id'      => $id,
+			'name'    => $this->option_name . '[' . $id . ']',
+			'section' => $section_id,
+			'type'    => $type,
+			'title'   => $title,
+			'extras'  => $extras,
+		];
+
+		$this->fields[ $id ] = $field_config;
+	}
+
+	/**
+	 * Get registered tabs.
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return Tabs_Config
+	 */
+	public function get_tabs(): array {
+		return $this->tabs;
+	}
+
+	/**
+	 * Check if at least one tab registered.
+	 *
+	 * @return bool
+	 */
+	public function has_tabs(): bool {
+		return ! empty( $this->tabs );
+	}
+
+	/**
+	 * Get registered sections.
+	 *
+	 * @param null|string $tab_id (Optional) The tab ID to retrieve sections for.
+	 *
+	 * @phpstan-param null|non-empty-string $tab_id
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return Sections_Config
+	 */
+	public function get_sections( ?string $tab_id = null ): array {
+		if ( null === $tab_id ) {
+			return $this->sections;
+		}
+
+		return array_filter(
+			$this->sections,
+			static fn( $section ) => $section['tab_id'] === $tab_id
+		);
+	}
+
+	/**
+	 * Get registered fields.
+	 *
+	 * @param null|string $section_id (Optional) The section ID to retrieve fields for.
+	 *
+	 * @phpstan-param null|non-empty-string $section_id
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return Fields_Config
+	 */
+	public function get_fields( ?string $section_id = null ): array {
+		if ( null === $section_id ) {
+			return $this->fields;
+		}
+
+		return array_filter(
+			$this->fields,
+			static fn( $field ) => $field['section'] === $section_id
+		);
 	}
 }

--- a/src/index.php
+++ b/src/index.php
@@ -1,2 +1,0 @@
-<?php
-// Remain blank for now.


### PR DESCRIPTION
## Description

This pull request establishes the core architectural foundation for the WP Settings Builder. The goal is to create a fluent, modern, and extensible framework for building WordPress settings pages following best practices.

It introduces a clear separation of concerns by implementing the following key components:

*   **`Settings`:** The main fluent interface and entry point for the builder.
*   **`Settings_Store`:** A dedicated class for managing the state of all registered tabs, sections, and fields.
*   **`Page_Renderer`:** Responsible for all HTML output, including the page wrapper, tabs, sections, and fields.
*   **`Interfaces` (`Settings_Interface`, `Field_Interface`):** Defines the public contracts for the builder and its fields, ensuring consistency.
*   **`Abstract_Field`:** A base class to provide common functionality for all future field types.

**Placeholders for Future Work:**

This PR also includes placeholders for key components that will be fully implemented in subsequent PRs:

*   **`Field_Factory`:** Ready to be populated with concrete field class implementations.
*   **`Sanitizer`:** The core sanitization logic will be built out as fields are added.
*   **`Asset_Manager`:** The asset enqueuing logic will be implemented when fields requiring CSS/JS are introduced.

This foundational PR provides the complete structure needed to begin adding functional fields.