### PR TITLE
feat: Implement basic input and description fields

### DIFF
--- a/src/Field_Factory.php
+++ b/src/Field_Factory.php
@@ -15,8 +15,8 @@ use WPTechnix\WP_Settings_Builder\Fields\Abstract_Field;
 /**
  * Creates instances of field objects based on their type.
  *
- * @phpstan-type Text_Field_Type 'text'
- * @phpstan-type Supported_Field_Type Text_Field_Type
+ * @phpstan-type Text_Field_Type 'text'|'textarea'|'number'|'email'|'password'|'url'
+ * @phpstan-type Supported_Field_Type Text_Field_Type|'description'
  *
  * @phpstan-import-type Field_Config from Abstract_Field
  */
@@ -39,7 +39,13 @@ final class Field_Factory {
 	 */
 	public function __construct() {
 		$this->fields = [
-			// TODO: add fields.
+			'text'        => Fields\Text_Field::class,
+			'textarea'    => Fields\Textarea_Field::class,
+			'number'      => Fields\Number_Field::class,
+			'email'       => Fields\Email_Field::class,
+			'password'    => Fields\Password_Field::class,
+			'url'         => Fields\Url_Field::class,
+			'description' => Fields\Description_Field::class,
 		];
 	}
 
@@ -62,7 +68,7 @@ final class Field_Factory {
 	 * @phpstan-return Text_Field_Type[]
 	 */
 	public function get_text_types(): array {
-		return [];
+		return [ 'text', 'textarea', 'number', 'email', 'password', 'url' ];
 	}
 
 	/**

--- a/src/Fields/Description_Field.php
+++ b/src/Fields/Description_Field.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Description Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Description Field Class
+ */
+final class Description_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		// This field only displays its description, which is handled by the renderer.
+		// It has no input element.
+		if ( ! empty( $this->field_config['extras']['description'] ) ) {
+			echo '<div ' . $this->build_attributes_string( $attributes ) . '>'; // phpcs:ignore WordPress.Security.EscapeOutput
+			echo wp_kses_post( $this->field_config['extras']['description'] );
+			echo '</div>';
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): mixed {
+		// No value to sanitize.
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): mixed {
+		return null;
+	}
+}

--- a/src/Fields/Email_Field.php
+++ b/src/Fields/Email_Field.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Email Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Email Field Class
+ */
+final class Email_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [ 'class' => 'regular-text' ];
+
+		$merged_attributes = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<input type="email" id="%s" name="%s" value="%s" %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			esc_attr( is_scalar( $value ) ? (string) $value : '' ),
+			$this->build_attributes_string( $merged_attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): string {
+		return sanitize_email( is_scalar( $value ) ? (string) $value : '' );
+	}
+}

--- a/src/Fields/Number_Field.php
+++ b/src/Fields/Number_Field.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Number Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Handles rendering and sanitization for number fields.
+ */
+final class Number_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [ 'class' => 'regular-text' ];
+		$merged_attributes  = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<input type="number" id="%s" name="%s" value="%s" %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			esc_attr( is_numeric( $value ) ? strval( $value ) : '' ),
+			$this->build_attributes_string( $merged_attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): float {
+		if ( ! is_numeric( $value ) ) {
+			return 0;
+		}
+		return (float) $value;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): float {
+		$default_value = parent::get_default_value();
+		return is_numeric( $default_value ) ? (float) $default_value : 0;
+	}
+}

--- a/src/Fields/Password_Field.php
+++ b/src/Fields/Password_Field.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Password Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Password Field Class
+ */
+final class Password_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [ 'class' => 'regular-text' ];
+
+		$merged_attributes = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<input type="password" id="%s" name="%s" value="%s" %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			esc_attr( is_scalar( $value ) ? (string) $value : '' ),
+			$this->build_attributes_string( $merged_attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): string {
+		// Passwords should not be modified beyond scalar casting.
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+}

--- a/src/Fields/Text_Field.php
+++ b/src/Fields/Text_Field.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Text Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Text Field Class
+ */
+final class Text_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [ 'class' => 'regular-text' ];
+
+		$merged_attributes = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<input type="text" id="%s" name="%s" value="%s" %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			esc_attr( is_scalar( $value ) ? (string) $value : '' ),
+			$this->build_attributes_string( $merged_attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): string {
+		return sanitize_text_field( is_scalar( $value ) ? (string) $value : '' );
+	}
+}

--- a/src/Fields/Textarea_Field.php
+++ b/src/Fields/Textarea_Field.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Textarea Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Textarea Field Class
+ */
+final class Textarea_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [
+			'rows'  => 5,
+			'cols'  => 50,
+			'class' => 'large-text',
+		];
+
+		$merged_attributes = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<textarea id="%s" name="%s" %s>%s</textarea>',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			$this->build_attributes_string( $merged_attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+			esc_textarea( is_scalar( $value ) ? (string) $value : '' )
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): string {
+		return sanitize_textarea_field( is_scalar( $value ) ? (string) $value : '' );
+	}
+}

--- a/src/Fields/Url_Field.php
+++ b/src/Fields/Url_Field.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * URL Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * URL Field Class
+ */
+final class Url_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$default_attributes = [ 'class' => 'regular-text' ];
+
+		$merged_attributes = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<input type="url" id="%s" name="%s" value="%s" %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			esc_attr( is_string( $value ) ? $value : '' ),
+			$this->build_attributes_string( $merged_attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): string {
+		return esc_url_raw( (string) $value );
+	}
+}

--- a/src/Page_Renderer.php
+++ b/src/Page_Renderer.php
@@ -109,7 +109,7 @@ final class Page_Renderer {
 
 			$value = $this->settings_store->get( $field_id, $field_object->get_default_value() );
 
-			$field_attributes = $field_config['attributes'] ?? [];
+			$field_attributes = $field_config['extras']['attributes'] ?? [];
 			if ( ! is_array( $field_attributes ) ) {
 				$field_attributes = [];
 			}
@@ -176,8 +176,8 @@ final class Page_Renderer {
 		foreach ( $this->settings_store->get_tabs() as $tab_id => $tab ) {
 			$url   = add_query_arg(
 				[
-					'page'       => $page_slug,
-					'active_tab' => $active_tab,
+					'page' => $page_slug,
+					'tab'  => $active_tab,
 				]
 			);
 			$class = 'nav-tab' . ( $tab_id === $active_tab ? ' nav-tab-active' : '' );


### PR DESCRIPTION
## Description

This pull request extends the core architecture by introducing the first set of fully functional field types, making the settings builder ready for a wide range of common use cases.

**New Features**
Seven new field types have been added, each with its own rendering and sanitization logic:

* `Text`
* `Textarea`
* `Number`
* `Email`
* `Password`
* `URL`
* `Description`: A special field type for rendering sanitized HTML content without an input element, useful for instructional text or custom markup within the settings form.

**Key Updates**

* **`Field_Factory`** is now populated with the new field classes and fully functional.
* **`Page_Renderer`** includes a fix for tab navigation URL generation to ensure proper tab switching.

**Next Steps**
While each field class now defines its own `sanitize()` method, the main `Sanitizer` class has not yet been implemented. The next step is to build the `Sanitizer` logic to process submitted data and delegate sanitization to the appropriate field objects.