### PR TITLE
feat: Add choice and selection field types

### DIFF
--- a/src/Field_Factory.php
+++ b/src/Field_Factory.php
@@ -16,7 +16,11 @@ use WPTechnix\WP_Settings_Builder\Fields\Abstract_Field;
  * Creates instances of field objects based on their type.
  *
  * @phpstan-type Text_Field_Type 'text'|'textarea'|'number'|'email'|'password'|'url'
- * @phpstan-type Supported_Field_Type Text_Field_Type|'description'
+ * @phpstan-type Acceptence_Field_Type 'checkbox'|'toggle'
+ * @phpstan-type Single_Choice_Field_Type 'select'|'radio'|'buttons_group'
+ * @phpstan-type Multiple_Choice_Field_Type 'multiselect'|'multicheck'
+ *
+ * @phpstan-type Supported_Field_Type 'description'|Text_Field_Type|Acceptence_Field_Type|Single_Choice_Field_Type|Multiple_Choice_Field_Type
  *
  * @phpstan-import-type Field_Config from Abstract_Field
  */
@@ -39,13 +43,20 @@ final class Field_Factory {
 	 */
 	public function __construct() {
 		$this->fields = [
-			'text'        => Fields\Text_Field::class,
-			'textarea'    => Fields\Textarea_Field::class,
-			'number'      => Fields\Number_Field::class,
-			'email'       => Fields\Email_Field::class,
-			'password'    => Fields\Password_Field::class,
-			'url'         => Fields\Url_Field::class,
-			'description' => Fields\Description_Field::class,
+			'description'   => Fields\Description_Field::class,
+			'text'          => Fields\Text_Field::class,
+			'textarea'      => Fields\Textarea_Field::class,
+			'number'        => Fields\Number_Field::class,
+			'email'         => Fields\Email_Field::class,
+			'password'      => Fields\Password_Field::class,
+			'url'           => Fields\Url_Field::class,
+			'checkbox'      => Fields\Checkbox_Field::class,
+			'toggle'        => Fields\Toggle_Field::class,
+			'select'        => Fields\Select_Field::class,
+			'radio'         => Fields\Radio_Field::class,
+			'buttons_group' => Fields\Buttons_Group_Field::class,
+			'multiselect'   => Fields\Multiselect_Field::class,
+			'multicheck'    => Fields\Multicheck_Field::class,
 		];
 	}
 
@@ -58,17 +69,6 @@ final class Field_Factory {
 	 */
 	public function get_supported_types(): array {
 		return array_keys( $this->fields );
-	}
-
-	/**
-	 * Get text-based field types.
-	 *
-	 * @return string[] An array of inline field type identifiers.
-	 *
-	 * @phpstan-return Text_Field_Type[]
-	 */
-	public function get_text_types(): array {
-		return [ 'text', 'textarea', 'number', 'email', 'password', 'url' ];
 	}
 
 	/**

--- a/src/Fields/Buttons_Group_Field.php
+++ b/src/Fields/Buttons_Group_Field.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Buttons Group Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
+
+/**
+ * Buttons Group Field Class
+ */
+final class Buttons_Group_Field extends Abstract_Field {
+
+	use Has_Choices_Trait;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$options     = $this->get_options();
+		$html_prefix = $this->field_config['extras']['html_prefix'];
+
+		$buttons_html = [];
+
+		foreach ( $options as $option_value => $option_label ) {
+			// Create a unique ID for each radio button for the label's 'for' attribute.
+			$radio_id   = $this->field_config['id'] . '_' . sanitize_key( (string) $option_value );
+			$is_checked = ( (string) $value === (string) $option_value );
+
+			// Determine the classes for the label to control its appearance.
+			$label_classes   = [
+				$html_prefix . '-button-group-label',
+				$is_checked ? $html_prefix . '-button-group-label-active' : '',
+			];
+			$label_class_str = trim( implode( ' ', $label_classes ) );
+
+			$buttons_html[] = sprintf(
+				'<label for="%s" class="%s">
+					<input type="radio" id="%s" name="%s" value="%s" class="screen-reader-text" %s %s />
+					<span class="%s-button-group-text">%s</span>
+				</label>',
+				esc_attr( $radio_id ),
+				esc_attr( $label_class_str ),
+				esc_attr( $radio_id ),
+				esc_attr( $this->field_config['name'] ),
+				esc_attr( (string) $option_value ),
+				checked( true, $is_checked, false ),
+				$this->build_attributes_string( $attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_attr( $html_prefix ),
+				esc_html( (string) $option_label )
+			);
+		}
+
+		// Wrap the buttons in a container for styling (e.g., with flexbox).
+		printf(
+			'<div class="%s-button-group" role="radiogroup">%s</div>',
+			esc_attr( $html_prefix ),
+			implode( "\n", $buttons_html ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): ?string {
+		$default_value = parent::get_default_value();
+
+		return $this->is_valid_choice( $default_value )
+			? (string) $default_value
+			: null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): ?string {
+		return $this->is_valid_choice( $value )
+			? (string) $value
+			: $this->get_default_value();
+	}
+}

--- a/src/Fields/Checkbox_Field.php
+++ b/src/Fields/Checkbox_Field.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Checkbox Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Checkbox Field Class
+ */
+final class Checkbox_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$description = $this->field_config['extras']['description'] ?? null;
+
+		// First, build the core <input> element HTML. This is used in both cases.
+		$input_html = sprintf(
+			'<input type="checkbox" id="%s" name="%s" value="1" %s %s />',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			checked( true, $value, false ),
+			$this->build_attributes_string( $attributes ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+
+		if ( is_string( $description ) && ! empty( $description ) ) {
+			// If a description exists, wrap the input and the description in a <label>.
+			// This makes the description text itself clickable, improving UX.
+			printf(
+				'<label for="%s">%s %s</label>',
+				esc_attr( $this->field_config['id'] ),
+				$input_html, // phpcs:ignore WordPress.Security.EscapeOutput
+				wp_kses_post( $description ) // Sanitize the description, allowing safe HTML.
+			);
+		} else {
+			// If no description exists, just output the input element.
+			// The main field title in the <th> still acts as the primary label.
+			echo $input_html; // phpcs:ignore WordPress.Security.EscapeOutput
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): bool {
+		$default_value = parent::get_default_value();
+		if ( is_bool( $default_value ) ) {
+			return $default_value;
+		}
+		return is_scalar( $default_value ) && '1' === (string) $default_value;
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		if ( is_scalar( $value ) ) {
+			return '1' === (string) $value;
+		}
+
+		return false;
+	}
+}

--- a/src/Fields/Multicheck_Field.php
+++ b/src/Fields/Multicheck_Field.php
@@ -12,7 +12,7 @@ namespace WPTechnix\WP_Settings_Builder\Fields;
 use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
 
 /**
- * Handles rendering and sanitization for a field with multiple checkboxes.
+ * Multicheck Field Class
  */
 final class Multicheck_Field extends Abstract_Field {
 

--- a/src/Fields/Multicheck_Field.php
+++ b/src/Fields/Multicheck_Field.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Multicheck Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
+
+/**
+ * Handles rendering and sanitization for a field with multiple checkboxes.
+ */
+final class Multicheck_Field extends Abstract_Field {
+
+	use Has_Choices_Trait;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$options        = $this->get_options();
+		$html_prefix    = $this->field_config['extras']['html_prefix'];
+		$current_values = is_array( $value ) ? $value : [];
+		$field_name     = $this->field_config['name'] . '[]'; // Append [] for array submission.
+
+		// Prepare the array of string values once, before the loop, for efficiency.
+		$string_current_values = array_map( 'strval', $current_values );
+
+		$fields_html = [];
+
+		foreach ( $options as $option_value => $option_label ) {
+			// Create a unique ID for each checkbox for the label's 'for' attribute.
+			$checkbox_id = $this->field_config['id'] . '_' . sanitize_key( (string) $option_value );
+			$is_checked  = in_array( (string) $option_value, $string_current_values, true );
+
+			$fields_html[] = sprintf(
+				// Wrap each checkbox in its own label for accessibility and layout control.
+				// A surrounding <div> or <p> could be used in custom CSS for line breaks.
+				'<label for="%s" class="%s-multicheck-label">
+					<input type="checkbox" id="%s" name="%s" value="%s" %s %s />
+					%s
+				</label>',
+				esc_attr( $checkbox_id ),
+				esc_attr( $html_prefix ),
+				esc_attr( $checkbox_id ),
+				esc_attr( $field_name ),
+				esc_attr( (string) $option_value ),
+				checked( true, $is_checked, false ),
+				$this->build_attributes_string( $attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_html( (string) $option_label )
+			);
+		}
+
+		// Output the checkboxes, separated by a newline for cleaner HTML source.
+		echo implode( "\n", $fields_html ); // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return array<int, string>
+	 */
+	public function get_default_value(): array {
+		$default_value = parent::get_default_value();
+
+		if ( ! is_array( $default_value ) ) {
+			return [];
+		}
+
+		// Filter the default values to ensure every item is a valid choice.
+		$valid_defaults = array_filter(
+			$default_value,
+			fn( $val ) => $this->is_valid_choice( $val )
+		);
+
+		// Re-index the array and ensure all values are strings.
+		return array_values( array_map( 'strval', $valid_defaults ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return array<int, string>
+	 */
+	public function sanitize( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			// If no checkboxes are checked, the key won't be in $_POST.
+			// The sanitizer will pass `null`, so we must return an empty array.
+			return [];
+		}
+
+		// Filter the submitted array to ensure every item is a valid choice.
+		$sanitized_values = array_filter(
+			$value,
+			fn( $v ) => $this->is_valid_choice( $v )
+		);
+
+		// Re-index the array and ensure all values are strings for consistent storage.
+		return array_values( array_map( 'strval', $sanitized_values ) );
+	}
+}

--- a/src/Fields/Multiselect_Field.php
+++ b/src/Fields/Multiselect_Field.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Multiselect Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
+
+/**
+ * Handles rendering and sanitization for multi-select dropdown fields.
+ */
+final class Multiselect_Field extends Abstract_Field {
+
+	use Has_Choices_Trait;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$options          = $this->get_options();
+		$html_prefix      = $this->field_config['extras']['html_prefix'];
+		$current_values   = is_array( $value ) ? $value : [];
+		$field_name_array = $this->field_config['name'] . '[]'; // Append [] for array submission.
+
+		$option_elements = [];
+		foreach ( $options as $option_value => $option_label ) {
+			$is_selected       = in_array( (string) $option_value, $current_values, true );
+			$option_elements[] = sprintf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( (string) $option_value ),
+				selected( true, $is_selected, false ),
+				esc_html( (string) $option_label )
+			);
+		}
+
+		$default_attributes = [
+			'multiple' => 'multiple',
+			'class'    => "{$html_prefix}-select2-field",
+		];
+		$merged_attributes  = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<select id="%s" name="%s" %s>%s</select>',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $field_name_array ),
+			$this->build_attributes_string( $merged_attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+			implode( "\n", $option_elements ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return array<int, string>
+	 */
+	public function get_default_value(): array {
+		$default_value = parent::get_default_value();
+
+		if ( ! is_array( $default_value ) ) {
+			return [];
+		}
+
+		// Filter the default values to ensure every item is a valid choice.
+		$valid_defaults = array_filter(
+			$default_value,
+			fn( $value ) => $this->is_valid_choice( $value )
+		);
+
+		// Re-index the array and ensure all values are strings.
+		return array_values( array_map( 'strval', $valid_defaults ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return array<int, string>
+	 */
+	public function sanitize( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			// If the submitted value isn't an array (e.g., nothing selected),
+			// return an empty array.
+			return [];
+		}
+
+		// Filter the submitted array to ensure every item is a valid choice.
+		$sanitized_values = array_filter(
+			$value,
+			fn( $v ) => $this->is_valid_choice( $v )
+		);
+
+		// Re-index the array and ensure all values are strings for consistent storage.
+		return array_values( array_map( 'strval', $sanitized_values ) );
+	}
+}

--- a/src/Fields/Radio_Field.php
+++ b/src/Fields/Radio_Field.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Radio Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use InvalidArgumentException;
+
+/**
+ * Radio Field Class
+ */
+final class Radio_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$options     = $this->field_config['extras']['options'] ?? null;
+		$html_prefix = $this->field_config['extras']['html_prefix'];
+
+		if ( ! is_array( $options ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'Options for field "%s" must be provided as an array.',
+					$this->field_config['id']
+				)
+			);
+		}
+
+		$fields_html = [];
+
+		foreach ( $options as $option_value => $option_label ) {
+			if ( ! is_string( $option_label ) && ! is_numeric( $option_label ) ) {
+				throw new InvalidArgumentException(
+					sprintf(
+						'Option labels for field "%s" must be provided as strings or numbers.',
+						$this->field_config['id']
+					)
+				);
+			}
+
+			$radio_id = $this->field_config['id'] . '_' . sanitize_key( (string) $option_value );
+
+			$fields_html[] = sprintf(
+				'<label for="%s" class="%s-radio-label">
+					<input type="radio" id="%s" name="%s" value="%s" %s %s />
+					%s
+				</label>',
+				esc_attr( $radio_id ),
+				esc_attr( $html_prefix ),
+				esc_attr( $radio_id ),
+				esc_attr( $this->field_config['name'] ),
+				esc_attr( (string) $option_value ),
+				checked( (string) $value, (string) $option_value, false ),
+				$this->build_attributes_string( $attributes ),
+				esc_html( (string) $option_label )
+			);
+		}
+
+		echo implode( "\n", $fields_html ); // phpcs:ignore WordPress.Security.EscapeOutput
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): ?string {
+		$options = $this->field_config['extras']['options'] ?? [];
+		$options = is_array( $options ) ? $options : [];
+
+		$default_value = parent::get_default_value();
+
+		if ( is_scalar( $default_value ) && array_key_exists( (string) $default_value, $options ) ) {
+			return (string) $default_value;
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): ?string {
+		$options = $this->field_config['extras']['options'] ?? [];
+		$options = is_array( $options ) ? $options : [];
+
+		return is_scalar( $value ) && array_key_exists( (string) $value, $options )
+			? (string) $value
+			: $this->get_default_value();
+	}
+}

--- a/src/Fields/Radio_Field.php
+++ b/src/Fields/Radio_Field.php
@@ -9,46 +9,32 @@ declare(strict_types=1);
 
 namespace WPTechnix\WP_Settings_Builder\Fields;
 
-use InvalidArgumentException;
+use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
 
 /**
  * Radio Field Class
  */
 final class Radio_Field extends Abstract_Field {
 
+	use Has_Choices_Trait;
+
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 * @throws \InvalidArgumentException When options are not provided as an array or invalid options are found.
 	 */
 	public function render( mixed $value, array $attributes ): void {
-		$options     = $this->field_config['extras']['options'] ?? null;
+		$options     = $this->get_options();
 		$html_prefix = $this->field_config['extras']['html_prefix'];
-
-		if ( ! is_array( $options ) ) {
-			throw new InvalidArgumentException(
-				sprintf(
-					'Options for field "%s" must be provided as an array.',
-					$this->field_config['id']
-				)
-			);
-		}
 
 		$fields_html = [];
 
 		foreach ( $options as $option_value => $option_label ) {
-			if ( ! is_string( $option_label ) && ! is_numeric( $option_label ) ) {
-				throw new InvalidArgumentException(
-					sprintf(
-						'Option labels for field "%s" must be provided as strings or numbers.',
-						$this->field_config['id']
-					)
-				);
-			}
-
+			// Create a unique ID for each radio button for the label's 'for' attribute.
 			$radio_id = $this->field_config['id'] . '_' . sanitize_key( (string) $option_value );
 
 			$fields_html[] = sprintf(
+				// Wrap each radio button in its own label for better accessibility and layout control.
 				'<label for="%s" class="%s-radio-label">
 					<input type="radio" id="%s" name="%s" value="%s" %s %s />
 					%s
@@ -59,11 +45,12 @@ final class Radio_Field extends Abstract_Field {
 				esc_attr( $this->field_config['name'] ),
 				esc_attr( (string) $option_value ),
 				checked( (string) $value, (string) $option_value, false ),
-				$this->build_attributes_string( $attributes ),
+				$this->build_attributes_string( $attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
 				esc_html( (string) $option_label )
 			);
 		}
 
+		// Output the radio buttons, separated by a newline for cleaner HTML source.
 		echo implode( "\n", $fields_html ); // phpcs:ignore WordPress.Security.EscapeOutput
 	}
 
@@ -71,25 +58,18 @@ final class Radio_Field extends Abstract_Field {
 	 * {@inheritDoc}
 	 */
 	public function get_default_value(): ?string {
-		$options = $this->field_config['extras']['options'] ?? [];
-		$options = is_array( $options ) ? $options : [];
-
 		$default_value = parent::get_default_value();
 
-		if ( is_scalar( $default_value ) && array_key_exists( (string) $default_value, $options ) ) {
-			return (string) $default_value;
-		}
-		return null;
+		return $this->is_valid_choice( $default_value )
+			? (string) $default_value
+			: null;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function sanitize( mixed $value ): ?string {
-		$options = $this->field_config['extras']['options'] ?? [];
-		$options = is_array( $options ) ? $options : [];
-
-		return is_scalar( $value ) && array_key_exists( (string) $value, $options )
+		return $this->is_valid_choice( $value )
 			? (string) $value
 			: $this->get_default_value();
 	}

--- a/src/Fields/Select_Field.php
+++ b/src/Fields/Select_Field.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Select Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+use WPTechnix\WP_Settings_Builder\Fields\Traits\Has_Choices_Trait;
+
+/**
+ * Select Field Class
+ */
+final class Select_Field extends Abstract_Field {
+
+	use Has_Choices_Trait;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException When options are not provided as an array or invalid options are found.
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$options = $this->get_options();
+
+		$option_elements = [];
+		foreach ( $options as $option_value => $option_label ) {
+			$option_elements[] = sprintf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( (string) $option_value ),
+				selected( (string) $value, (string) $option_value, false ),
+				esc_html( (string) $option_label )
+			);
+		}
+
+		$default_attributes = [ 'class' => 'regular-text' ];
+		$merged_attributes  = array_merge( $default_attributes, $attributes );
+
+		printf(
+			'<select id="%s" name="%s" %s>%s</select>',
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			$this->build_attributes_string( $merged_attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+			implode( "\n", $option_elements ) // phpcs:ignore WordPress.Security.EscapeOutput
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): ?string {
+		$default_value = parent::get_default_value();
+
+		return $this->is_valid_choice( $default_value )
+			? (string) $default_value
+			: null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): ?string {
+		return $this->is_valid_choice( $value )
+			? (string) $value
+			: $this->get_default_value();
+	}
+}

--- a/src/Fields/Toggle_Field.php
+++ b/src/Fields/Toggle_Field.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Toggle Field Class
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields;
+
+/**
+ * Toggle Field Class
+ *
+ * Renders a checkbox styled as a toggle switch.
+ */
+final class Toggle_Field extends Abstract_Field {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function render( mixed $value, array $attributes ): void {
+		$description = $this->field_config['extras']['description'] ?? null;
+		$html_prefix = $this->field_config['extras']['html_prefix'];
+
+		// Build the core toggle switch HTML structure.
+		$toggle_html = sprintf(
+			'<span class="%s-toggle">
+				<input type="checkbox" id="%s" name="%s" value="1" %s %s />
+				<span class="%s-toggle-slider"></span>
+			</span>',
+			esc_attr( $html_prefix ),
+			esc_attr( $this->field_config['id'] ),
+			esc_attr( $this->field_config['name'] ),
+			checked( true, $value, false ),
+			$this->build_attributes_string( $attributes ), // phpcs:ignore WordPress.Security.EscapeOutput
+			esc_attr( $html_prefix )
+		);
+
+		if ( is_string( $description ) && ! empty( $description ) ) {
+			// If a description exists, wrap the toggle and the description in a <label>.
+			// This makes the description text itself clickable.
+			printf(
+				'<label for="%s">%s %s</label>',
+				esc_attr( $this->field_config['id'] ),
+				$toggle_html, // phpcs:ignore WordPress.Security.EscapeOutput
+				wp_kses_post( $description )
+			);
+		} else {
+			// If no description exists, just output the toggle structure.
+			// The main field title in the <th> will act as the label.
+			echo $toggle_html; // phpcs:ignore WordPress.Security.EscapeOutput
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_default_value(): bool {
+		$default_value = parent::get_default_value();
+		if ( is_bool( $default_value ) ) {
+			return $default_value;
+		}
+		return is_scalar( $default_value ) && '1' === (string) $default_value;
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function sanitize( mixed $value ): bool {
+		if ( is_bool( $value ) ) {
+			return $value;
+		}
+		if ( is_scalar( $value ) ) {
+			return '1' === (string) $value;
+		}
+
+		return false;
+	}
+}

--- a/src/Fields/Traits/Has_Choices_Trait.php
+++ b/src/Fields/Traits/Has_Choices_Trait.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Provides common functionality for fields that have a list of options,
+ * like 'select' and 'radio'.
+ *
+ * @package WPTechnix\WP_Settings_Builder\Fields\Traits
+ */
+
+declare(strict_types=1);
+
+namespace WPTechnix\WP_Settings_Builder\Fields\Traits;
+
+use InvalidArgumentException;
+
+/**
+ * Provides common functionality for fields that have a list of options,
+ * like 'select' and 'radio'.
+ */
+trait Has_Choices_Trait {
+
+	/**
+	 * Retrieves and validates the options array for the field.
+	 *
+	 * @return array
+	 *
+	 * @phpstan-return array<string|int, string|int>
+	 *
+	 * @throws InvalidArgumentException If options are not a valid array.
+	 */
+	private function get_options(): array {
+		$options = $this->field_config['extras']['options'] ?? null;
+
+		if ( ! is_array( $options ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					'The "options" extra must be provided as an array for the "%s" field.',
+					$this->field_config['id']
+				)
+			);
+		}
+		return $options;
+	}
+
+	/**
+	 * Checks if a given value is a valid key in the options array.
+	 *
+	 * @param mixed $value The value to check.
+	 *
+	 * @return bool
+	 */
+	private function is_valid_choice( mixed $value ): bool {
+		if ( ! is_scalar( $value ) ) {
+			return false;
+		}
+
+		try {
+			$options = $this->get_options();
+			return array_key_exists( (string) $value, $options );
+		} catch ( InvalidArgumentException ) {
+			return false;
+		}
+	}
+}

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -273,9 +273,15 @@ final class Settings implements Settings_Interface {
 
 			$field_type = $field['type'];
 
-			if ( in_array( $field_type, $this->field_factory->get_text_types(), true ) ||
-				( in_array( $field_type, [ 'checkbox', 'toggle' ], true ) && empty( $field['extras']['description'] ) )
-			) {
+			$inline_types     = [ 'text', 'textarea', 'number', 'email', 'password', 'url', 'select', 'multiselect' ];
+			$acceptence_types = [ 'checkbox', 'toggle' ];
+
+			$inline_field     = in_array( $field_type, $inline_types, true );
+			$acceptence_field = in_array( $field_type, $acceptence_types, true );
+
+			$no_description = empty( $field['extras']['description'] );
+
+			if ( $inline_field || ( $acceptence_field && $no_description ) ) {
 				$args['label_for'] = $id;
 			}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -271,7 +271,11 @@ final class Settings implements Settings_Interface {
 		foreach ( $this->settings_store->get_fields() as $id => $field ) {
 			$args = $field;
 
-			if ( in_array( $field['type'], $this->field_factory->get_text_types(), true ) ) {
+			$field_type = $field['type'];
+
+			if ( in_array( $field_type, $this->field_factory->get_text_types(), true ) ||
+				( in_array( $field_type, [ 'checkbox', 'toggle' ], true ) && empty( $field['extras']['description'] ) )
+			) {
 				$args['label_for'] = $id;
 			}
 


### PR DESCRIPTION
## Description

This pull request introduces a suite of choice-based field types, allowing developers to present users with a predefined set of options.

**New Field Types Added:**

This PR adds the following fully functional and secure field types:

*   **`Radio_Field`**: Renders a standard list of radio buttons for single-choice selection.
*   **`Checkbox_Field`**: Renders a single checkbox for boolean (on/off) values. Intelligently uses its description as a clickable label for improved UX.
*   **`Toggle_Field`**: Renders a checkbox styled as a modern toggle switch, providing a better UI for boolean options. Also uses its description as a clickable label.
*   **`Select_Field`**: Renders a standard dropdown for single-choice selection.
*   **`Multiselect_Field`**: Renders a select box that allows for multiple selections, storing values as an array.
*   **`Multicheck_Field`**: Renders a list of checkboxes, allowing for multiple selections.
*   **`Buttons_Group_Field`**: Renders an accessible, button-style toolbar for single-choice selection, providing a more modern UI than traditional radio buttons.

All fields include robust, type-safe sanitization to ensure that only valid, predefined options can be saved to the database. The logic in `Settings.php` was also updated to correctly handle the `label_for` attribute for checkbox-style fields to ensure valid and accessible HTML output.


**Architectural Improvements:**

To promote code reuse and maintainability, a `Has_Choices_Trait` was created. This trait centralizes the core logic for handling the `options` array, including validation and checking if a submitted value is a valid choice. This DRY approach is used by all new fields in this PR.
